### PR TITLE
Header 'strstream' replaced by the header 'sstream'

### DIFF
--- a/src/Open3DMotion/MotionFile/Formats/C3D/FileFormatC3D.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/C3D/FileFormatC3D.cpp
@@ -13,7 +13,7 @@
 
 #include <map>
 #include <limits>
-#include <strstream>
+#include <sstream>
 #include <stdio.h>
 #include <math.h>
 
@@ -349,7 +349,7 @@ namespace Open3DMotion
 					string recordname_long("DESCRIPTIONS");
 					if (setofnames > 0)
 					{
-						std::ostrstream number;
+						std::ostringstream number;
 						number << (setofnames+1) << std::ends;
 						recordname_short += number.str();
 						recordname_long += number.str();
@@ -384,8 +384,8 @@ namespace Open3DMotion
         else
         {
           // invent a Int16 name
-          ostrstream osTempname;
-          osTempname << "M" << (i+1) << '\0';
+          std::ostringstream osTempname;
+          osTempname << "M" << (i+1);
 					ts->Channel = osTempname.str();
         }
 
@@ -551,8 +551,8 @@ namespace Open3DMotion
         else
         {
           // invent a Int16 name
-          ostrstream tempname;
-          tempname << "CH" << (i+1) << '\0';
+          std::ostringstream tempname;
+          tempname << "CH" << (i+1);
 					ts->Channel = tempname.str();
         }
 
@@ -795,7 +795,7 @@ namespace Open3DMotion
 			string descrecordname = "DESCRIPTIONS";
 			if (setnumber > 0)
 			{
-				ostrstream number;
+				std::ostringstream number;
 				number << (setnumber+1) << ends;
 				descrecordname += number.str();
 			}
@@ -1032,16 +1032,16 @@ namespace Open3DMotion
 
 					if (ianalog < num_analog)
 					{
-            ostrstream sname, sdesc;
+            std::ostringstream sname, sdesc;
             if (platetype[i] == 3)	// Kistler plates
             {
-              sname << "F" << (i+1) << strForceLabelK[ichannel] << '\0';
-              sdesc << "Force Plate #" << (i+1) << " - " << strForceDescK[ichannel] << '\0';
+              sname << "F" << (i+1) << strForceLabelK[ichannel];
+              sdesc << "Force Plate #" << (i+1) << " - " << strForceDescK[ichannel];
             }
             else if (platetype[i] == 2 || platetype[i] == 4)	// AMTI plates
             {
-              sname << strForceLabelA[ichannel] << (i+1) << '\0';
-              sdesc << "Force Plate #" << (i+1) << " - " << strForceDescA[ichannel] << '\0';
+              sname << strForceLabelA[ichannel] << (i+1);
+              sdesc << "Force Plate #" << (i+1) << " - " << strForceDescA[ichannel];
             }
 						else
 						{
@@ -1075,8 +1075,8 @@ namespace Open3DMotion
     {
 			for (i = 0; i < label_marker.size(); i++)
 			{
-				ostrstream strlabels;
-				ostrstream strdescs;
+				std::ostringstream strlabels;
+				std::ostringstream strdescs;
 				strlabels << "LABELS";
 				strdescs << "DESCRIPTIONS";
 				if (i > 0)
@@ -1086,8 +1086,8 @@ namespace Open3DMotion
 				}
 				strlabels << ends;
 				strdescs << ends;
-				param.AddRecord(new C3DRecordText(1, strlabels.str(), "Short marker names", label_marker[i], maxchars_label_marker));
-				param.AddRecord(new C3DRecordText(1, strdescs.str(),  "Marker names", desc_marker[i], maxchars_pointdesc));
+				param.AddRecord(new C3DRecordText(1, strlabels.str().c_str(), "Short marker names", label_marker[i], maxchars_label_marker));
+				param.AddRecord(new C3DRecordText(1, strdescs.str().c_str(),  "Marker names", desc_marker[i], maxchars_pointdesc));
 			}
     }
 

--- a/src/Open3DMotion/MotionFile/Formats/MDF/FileFormatMDF.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/MDF/FileFormatMDF.cpp
@@ -13,7 +13,7 @@
 #include "Open3DMotion/Biomechanics/Trial/Gait/GaitEvents.h"
 #include "Open3DMotion/MotionFile/Formats/MDF/ForcePlateMDF.h"
 
-#include <strstream>
+#include <sstream>
 
 #ifdef __GNUC__
 #define _stricmp strcasecmp
@@ -412,7 +412,7 @@ namespace Open3DMotion
 			// generate name from marker number if none exists
 			if (name.empty())
       {
-        std::ostrstream sname;
+        std::ostringstream sname;
         sname << "Marker" << (i+1) << std::ends;
         name = sname.str();
 			}
@@ -486,7 +486,7 @@ namespace Open3DMotion
       }
       else
       {
-        std::ostrstream sname;
+        std::ostringstream sname;
         sname << "EMG" << (i+1) << std::ends;
         name = sname.str();
       }
@@ -578,7 +578,7 @@ namespace Open3DMotion
           {
             // TODO: construct name according to force plate type
             //       (Fx, Mx, etc)
-            std::ostrstream sname;
+            std::ostringstream sname;
             sname << "Force" << (index_file_force+1) << std::ends;
 						name = sname.str();
           }
@@ -1483,7 +1483,7 @@ namespace Open3DMotion
 			// "NotUsedX" names for dummy channels
 			for (i = emgindex.size(); i < num_emg; i++)
 			{
-				std::ostrstream unusedname;
+				std::ostringstream unusedname;
 				unusedname << "NotUsed" << (i+1) << std::ends;
 				EncodeMDFString(os, unusedname.str(), true);
 			}
@@ -1628,11 +1628,11 @@ namespace Open3DMotion
         if (index == NODATA)
         {
 	        // dummy entries for nodata channels
-          std::ostrstream strName;
+          std::ostringstream strName;
           strName << "NotUsed" << (ichannel+1) << '\0';
-          wElements = (UInt16)strlen(strName.str()) + 1;
+          wElements = (UInt16)strName.str().length() + 1;
           os.write((const char*)&wElements,2);
-          os.write(strName.str(),wElements);
+          os.write(strName.str().c_str(),wElements);
         }
 				else
 				{

--- a/src/Open3DMotion/OpenORM/IO/BSON/BSONObjectIdHolder.cpp
+++ b/src/Open3DMotion/OpenORM/IO/BSON/BSONObjectIdHolder.cpp
@@ -6,7 +6,7 @@
 --*/
 
 #include "BSONObjectIdHolder.h"
-#include <strstream>
+#include <sstream>
 #include <iomanip>
 
 namespace Open3DMotion
@@ -18,13 +18,13 @@ namespace Open3DMotion
 
 	void BSONObjectIdHolder::FromBinary(const BSONObjectIdBinary& binary)
 	{
-		std::ostrstream buffer;
+		std::ostringstream buffer;
 		for (size_t i = 0; i < BSONObjectIdBytes; i++)
 		{
 			buffer << std::setfill('0') << std::setw(2) << std::hex << (int)binary[i];
 		}
 		buffer << std::ends;
-		BSONObjectId.Value() = buffer.str();
+		BSONObjectId.Value() = buffer.str().c_str();
 	}
 
 	void BSONObjectIdHolder::ToBinary(BSONObjectIdBinary& binary) const


### PR DESCRIPTION
The header 'strstream' is now deprecated. The use of 'sstream' doesn't need to include the null character ('\0') at the end of a string. All the unit tests passed after this modification.
