### PR TITLE
[FIX] Crash of the MATextReader class if the given file doesn't exist.

### DIFF
--- a/src/Open3DMotion/MotionFile/Formats/CODAText/MATextReader.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/CODAText/MATextReader.cpp
@@ -16,6 +16,9 @@ namespace Open3DMotion
 
 	bool MATextReader::Read(std::istream& is)
 	{
+	  if (is.fail())
+      return false;
+	  
 		MATextInputStream tf(is);
 
 		// file format descriptor line
@@ -41,9 +44,9 @@ namespace Open3DMotion
 			return false;
 
 		// time headings must be first
-		if (group[0].compare("Time") != 0)
+		if ((!group.empty()) && (group[0].compare("Time") != 0))
 			return false;
-		if (channel[0].compare("Time") != 0)
+		if ((!channel.empty()) && channel[0].compare("Time") != 0)
 			return false;
 
 		// copy to array
@@ -68,14 +71,17 @@ namespace Open3DMotion
 			heading.push_back(MATextColHeading(groupname, channelname, unitsname));
 		}
 
-		// read data
-		while (tf.ReadDataRow(data, numcolumns))
-			;
+    if (numcolumns != 0)
+    {
+    	// read data
+    	while (tf.ReadDataRow(data, numcolumns))
+    		;
 
-		// must have complete rows
-		if (data.size() % numcolumns != 0)
-			return false;
-
+    	// must have complete rows
+    	if (data.size() % numcolumns != 0)
+    		return false;
+    }
+    
 		return true;
 	}
 

--- a/src/Open3DMotionTest/MotionFile/TestMATextReader.cpp
+++ b/src/Open3DMotionTest/MotionFile/TestMATextReader.cpp
@@ -9,15 +9,24 @@ class TestMATextReader : public CppUnit::TestFixture
 {
 public:
 	CPPUNIT_TEST_SUITE( TestMATextReader );
+	CPPUNIT_TEST(testMispelledFile);
 	CPPUNIT_TEST(testGraphData);
 	CPPUNIT_TEST_SUITE_END();
 
 public:
 
+  void testMispelledFile();
 	void testGraphData();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION( TestMATextReader );
+
+void TestMATextReader::testMispelledFile()
+{
+  MATextReader reader;
+	ifstream input("Open3DMotionTest/Data/CODAText/NoFile.txt", ios::binary);
+	CPPUNIT_ASSERT( reader.Read(input) == false);
+}
 
 void TestMATextReader::testGraphData()
 {


### PR DESCRIPTION
Accidently I discovered that if the filename given to the method `MATextReader::Read` doesn't exist, then the variable `group`and `channel` are empty. Morever, as `numcolumns` is then equal to 0, then the while loop is infinite. The modulo `%` operator send also an error in this last case. 

Finally, I added the test at the beginning on the given input stream to know if there is already an error `if (is.fail())`. A unit test was added to cover this problem
