### PR TITLE
MSVC warning C4996: use of unsafe functions

### DIFF
--- a/src/Open3DMotion/MotionFile/MotionFileHandler.cpp
+++ b/src/Open3DMotion/MotionFile/MotionFileHandler.cpp
@@ -10,6 +10,11 @@
 #include "Open3DMotion/MotionFile/FileFormatOptions.h"
 #include "Open3DMotion/OpenORM/Mappings/RichBinary/BinMemFactoryDefault.h"
 
+#if defined(_MSC_VER)
+  // Disable unsafe warning (use of the function 'fopen' instead of 'fopen_s' for portability reasons;
+  #pragma warning( disable : 4996 )
+#endif
+
 namespace Open3DMotion
 {
 	using namespace std;

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLBool.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLBool.cpp
@@ -10,6 +10,11 @@
 #include "XMLWritingMachine.h"
 #include <iomanip>
 
+#if defined(_MSC_VER)
+  // Disable unsafe warning (use of the function 'sscanf' instead of 'sscanf_s' for portability reasons;
+  #pragma warning( disable : 4996 )
+#endif
+
 namespace Open3DMotion
 {
 	void ReadWriteXMLBool::WriteValue(XMLWritingMachine& writer, const TreeValue* value) const

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLFloat64.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLFloat64.cpp
@@ -10,6 +10,11 @@
 #include "XMLWritingMachine.h"
 #include <iomanip>
 
+#if defined(_MSC_VER)
+  // Disable unsafe warning (use of the function 'sscanf' instead of 'sscanf_s' for portability reasons;
+  #pragma warning( disable : 4996 )
+#endif
+
 namespace Open3DMotion
 {
 	void ReadWriteXMLFloat64::WriteValue(XMLWritingMachine& writer, const TreeValue* value) const

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLInt32.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLInt32.cpp
@@ -10,6 +10,11 @@
 #include "XMLWritingMachine.h"
 #include <iomanip>
 
+#if defined(_MSC_VER)
+  // Disable unsafe warning (use of the function 'sscanf' instead of 'sscanf_s' for portability reasons;
+  #pragma warning( disable : 4996 )
+#endif
+
 namespace Open3DMotion
 {
 	TreeValue* ReadWriteXMLInt32::ReadValue(XMLReadingMachine& /*reader*/, const pugi::xml_node& element) const


### PR DESCRIPTION
Remove the warnings C4996 given by MSVC due to the use of unsafe function (fopen, sscanf).
