### PR TITLE
[FIX] Several headers are missing when compiling Open3DMotion with GCC 4...

### DIFF
--- a/src/Open3DMotion/MotionFile/Formats/MDF/FileFormatMDF.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/MDF/FileFormatMDF.cpp
@@ -14,6 +14,8 @@
 #include "Open3DMotion/MotionFile/Formats/MDF/ForcePlateMDF.h"
 
 #include <sstream>
+#include <memory>
+#include <cstring>
 
 namespace Open3DMotion
 {

--- a/src/Open3DMotion/MotionFile/MotionFileFormat.cpp
+++ b/src/Open3DMotion/MotionFile/MotionFileFormat.cpp
@@ -6,6 +6,7 @@
 --*/
 
 #include "MotionFileFormat.h"
+#include <cstring>
 
 namespace Open3DMotion
 {

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLBinary.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLBinary.cpp
@@ -10,6 +10,7 @@
 #include "XMLWritingMachine.h"
 #include "Open3DMotion/OpenORM/Leaves/MemoryHandlerBasic.h"
 #include <pugixml.hpp>
+#include <cstring>
 
 extern "C"
 {

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLBool.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLBool.cpp
@@ -9,6 +9,7 @@
 #include "XMLReadingMachine.h"
 #include "XMLWritingMachine.h"
 #include <iomanip>
+#include <cstdio>
 
 #if defined(_MSC_VER)
   // Disable unsafe warning (use of the function 'sscanf' instead of 'sscanf_s' for portability reasons;

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLCompound.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLCompound.cpp
@@ -10,6 +10,7 @@
 #include "XMLWritingMachine.h"
 #include <set>
 #include <pugixml.hpp>
+#include <memory>
 
 namespace Open3DMotion
 {

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLFloat64.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLFloat64.cpp
@@ -9,6 +9,7 @@
 #include "XMLReadingMachine.h"
 #include "XMLWritingMachine.h"
 #include <iomanip>
+#include <cstdio>
 
 #if defined(_MSC_VER)
   // Disable unsafe warning (use of the function 'sscanf' instead of 'sscanf_s' for portability reasons;

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLInt32.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLInt32.cpp
@@ -9,6 +9,7 @@
 #include "XMLReadingMachine.h"
 #include "XMLWritingMachine.h"
 #include <iomanip>
+#include <cstdio>
 
 #if defined(_MSC_VER)
   // Disable unsafe warning (use of the function 'sscanf' instead of 'sscanf_s' for portability reasons;

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLList.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLList.cpp
@@ -9,6 +9,7 @@
 #include "XMLReadingMachine.h"
 #include "XMLWritingMachine.h"
 #include <pugixml.hpp>
+#include <memory>
 
 namespace Open3DMotion
 {

--- a/src/Open3DMotion/OpenORM/IO/XML/XMLWritingMachine.h
+++ b/src/Open3DMotion/OpenORM/IO/XML/XMLWritingMachine.h
@@ -11,6 +11,8 @@
 #include "XMLReadWriteMachine.h"
 #include "Open3DMotion/OpenORM/TreeValue.h"
 
+#include <ostream>
+
 namespace Open3DMotion
 {
 	class XMLWritingMachine : public XMLReadWriteMachine

--- a/src/Open3DMotion/OpenORM/TreeValue.cpp
+++ b/src/Open3DMotion/OpenORM/TreeValue.cpp
@@ -6,7 +6,7 @@
 --*/
 
 #include "Open3DMotion/OpenORM/TreeValue.h"
-#include <string>
+#include <cstring>
 
 namespace Open3DMotion
 {


### PR DESCRIPTION
....4.5 (Ubuntu 10.10).
