### PR TITLE
Missing headers under Ubuntu 12.04 (GCC 4.6.3).

### DIFF
--- a/src/Open3DMotion/MotionBundle/MOBL.h
+++ b/src/Open3DMotion/MotionBundle/MOBL.h
@@ -14,6 +14,8 @@
 #include "Open3DMotion/MotionFile/MotionFileException.h"
 #include "Open3DMotion/OpenORM/Mappings/RichBinary/BinMemFactoryDefault.h"
 
+#include <memory>
+
 namespace Open3DMotion
 {
 	class BSONInputStream;

--- a/src/Open3DMotion/MotionFile/Formats/C3D/FileFormatC3D.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/C3D/FileFormatC3D.cpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <limits>
 #include <sstream>
+#include <memory>
 #include <stdio.h>
 #include <math.h>
 

--- a/src/Open3DMotion/MotionFile/Formats/CODAText/MATextInputStream.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/CODAText/MATextInputStream.cpp
@@ -6,6 +6,7 @@
 --*/
 
 #include "Open3DMotion/MotionFile/Formats/CODAText/MATextInputStream.h"
+#include <stdio.h>
 
 namespace Open3DMotion
 {

--- a/src/Open3DMotion/MotionFile/Formats/CODAText/MATextReader.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/CODAText/MATextReader.cpp
@@ -8,6 +8,8 @@
 #include "Open3DMotion/MotionFile/Formats/CODAText/MATextReader.h"
 #include "Open3DMotion/MotionFile/Formats/CODAText/MATextInputStream.h"
 
+#include <stdio.h>
+
 namespace Open3DMotion
 {
 	MATextReader::MATextReader()

--- a/src/Open3DMotion/MotionFile/Formats/MoXie/FileFormatMoXie.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/MoXie/FileFormatMoXie.cpp
@@ -16,7 +16,7 @@
 #include <float.h>
 #include <sstream>
 #include <iomanip>
-
+#include <memory>
 namespace Open3DMotion
 {
 	const char* moxie_xml_doc = "moxie_viewer_datafile";

--- a/src/Open3DMotion/MotionFile/Formats/XMove/FileFormatXMove.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/XMove/FileFormatXMove.cpp
@@ -16,6 +16,7 @@
 #include "Open3DMotion/OpenORM/Mappings/RichBinary/RichBinaryConvertFloat.h"
 #include "Open3DMotion/OpenORM/Mappings/RichBinary/BinMemFactoryDefault.h"
 #include <pugixml.hpp>
+#include <memory>
 
 namespace Open3DMotion
 {	

--- a/src/Open3DMotion/MotionFile/Formats/XMove/XMLWritingMachineLegacy.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/XMove/XMLWritingMachineLegacy.cpp
@@ -8,8 +8,9 @@
 #include "XMLWritingMachineLegacy.h"
 #include "Open3DMotion/OpenORM/IO/XML/ReadWriteXML.h"
 #include "Open3DMotion/OpenORM/Mappings/RichBinary/BinaryFieldSpec.h"
-#include "Open3DMotion/Biomechanics//Trial/Trial.h"
+#include "Open3DMotion/Biomechanics/Trial/Trial.h"
 #include <pugixml.hpp>
+#include <memory>
 
 namespace Open3DMotion
 {

--- a/src/Open3DMotion/OpenORM/IO/BSON/BSONInputStreamGZ.cpp
+++ b/src/Open3DMotion/OpenORM/IO/BSON/BSONInputStreamGZ.cpp
@@ -7,6 +7,8 @@
 
 #include "BSONInputStreamGZ.h"
 #include <zlib.h>
+#include <memory.h>
+#include <stdlib.h>
 
 namespace Open3DMotion
 {

--- a/src/Open3DMotion/OpenORM/IO/BSON/BSONObjectIdHolder.cpp
+++ b/src/Open3DMotion/OpenORM/IO/BSON/BSONObjectIdHolder.cpp
@@ -8,6 +8,7 @@
 #include "BSONObjectIdHolder.h"
 #include <sstream>
 #include <iomanip>
+#include <stdio.h>
 
 namespace Open3DMotion
 {

--- a/src/Open3DMotion/OpenORM/IO/BSON/BSONReader.cpp
+++ b/src/Open3DMotion/OpenORM/IO/BSON/BSONReader.cpp
@@ -18,6 +18,8 @@
 #include "BSONObjectIdHolder.h"
 #include "BSONTimestampHolder.h"
 
+#include <memory>
+
 namespace Open3DMotion
 {
 	BSONReader::BSONReader(BSONInputStream& _input, const BinMemFactory& _memfactory) :

--- a/src/Open3DMotion/OpenORM/IO/BSON/BSONReaderMOBL.cpp
+++ b/src/Open3DMotion/OpenORM/IO/BSON/BSONReaderMOBL.cpp
@@ -10,6 +10,8 @@
 #include "Open3DMotion/OpenORM/Leaves/TreeBinary.h"
 #include "Open3DMotion/OpenORM/Mappings/RichBinary/BinMemFactory.h"
 
+#include <memory>
+
 namespace Open3DMotion
 {
 	TreeValue* BSONReaderMOBL::ReadElementValue(UInt8 elementcode)  throw (BSONReadException)

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLBinary.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLBinary.cpp
@@ -19,6 +19,8 @@ extern "C"
 #include <b64/cdecode.h>
 }
 
+#include <memory>
+
 namespace Open3DMotion
 {
 	void ReadWriteXMLBinary::WriteValue(XMLWritingMachine& writer, const TreeValue* value) const

--- a/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLInt32.cpp
+++ b/src/Open3DMotion/OpenORM/IO/XML/ReadWriteXMLInt32.cpp
@@ -9,6 +9,7 @@
 #include "XMLReadingMachine.h"
 #include "XMLWritingMachine.h"
 #include <iomanip>
+#include <stdio.h>
 
 #if defined(_MSC_VER)
   // Disable unsafe warning (use of the function 'sscanf' instead of 'sscanf_s' for portability reasons;

--- a/src/Open3DMotion/OpenORM/Mappings/RichBinary/RichBinary.cpp
+++ b/src/Open3DMotion/OpenORM/Mappings/RichBinary/RichBinary.cpp
@@ -7,6 +7,9 @@
 
 #include "Open3DMotion/OpenORM/Mappings/RichBinary/RichBinary.h"
 
+#include <memory>
+#include <memory.h>
+
 namespace Open3DMotion
 {
 	const char RichBinary::BinaryName[] = "Data";

--- a/src/Open3DMotion/OpenORM/Types.h
+++ b/src/Open3DMotion/OpenORM/Types.h
@@ -20,8 +20,14 @@
 #endif
 
 #ifdef __GNUC__
+#include <string.h>
 #define _stricmp strcasecmp
 #define _finite isfinite
+#endif
+
+#ifndef SIZE_MAX
+#include <limits>
+#define SIZE_MAX std::numeric_limits<size_t>::max()
 #endif
 
 namespace Open3DMotion

--- a/src/Open3DMotionTest/Biomechanics/Algorithms/MOSHFIT/TestRigidBodyShapeCollection.cpp
+++ b/src/Open3DMotionTest/Biomechanics/Algorithms/MOSHFIT/TestRigidBodyShapeCollection.cpp
@@ -7,6 +7,10 @@
 #include <time.h>
 #include <list>
 
+#ifndef CLK_TCK
+  #define CLK_TCK CLOCKS_PER_SEC
+#endif
+
 using namespace Open3DMotion;
 using namespace std;
 


### PR DESCRIPTION
I know you do not support Linux but in case your are interested, The inclusion of these headers fix the compilation errors and all the unit tests (minus one - see comment in the issue #11) passed.
