### PR TITLE
Adding the -Wcast-align flag to Clang warns about pointer casts that inc...

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,10 @@ SET(CMAKE_DEBUG_POSTFIX d)
 
 # Additional warning flags on GNU C on Apple
 if(APPLE)
-  set(CMAKE_CXX_FLAGS_DEBUG  "-g -Wnon-virtual-dtor -Wno-long-long -ansi -Wchar-subscripts -Wall -Wextra -Wpointer-arith -Wformat-security -Woverloaded-virtual -fno-check-new -fno-common")
+  set(CMAKE_CXX_FLAGS_DEBUG  "-g -Wnon-virtual-dtor -Wno-long-long -Wchar-subscripts -Wall -Wextra -Wpointer-arith -Wformat-security -Woverloaded-virtual -Wcast-align -fno-common")
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS_DEBUG  ${CMAKE_CXX_FLAGS_DEBUG} "-ansi -fno-check-new ")
+  endif(CMAKE_COMPILER_IS_GNUCXX)
 endif(APPLE)
 
 # Optionally use static libraries on windows

--- a/src/Open3DMotion/MotionFile/Formats/MDF/ForcePlateMDF.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/MDF/ForcePlateMDF.cpp
@@ -88,7 +88,7 @@ namespace Open3DMotion
 		if (iplate < data[VAR_FORCE_PLATE_FLAGS].size() &&
 				data[VAR_FORCE_PLATE_FLAGS][iplate].size() >= 2)
     {
-      UInt16 wType = *(UInt16*)(&(data[VAR_FORCE_PLATE_FLAGS][iplate][0]));
+      UInt16 wType = *reinterpret_cast<UInt16*>(&(data[VAR_FORCE_PLATE_FLAGS][iplate][0]));
       id = wType >> 8;
     }
 
@@ -109,7 +109,7 @@ namespace Open3DMotion
     if (iplate < data[VAR_FORCE_PLATE_CONSTANTS].size() &&
 				data[VAR_FORCE_PLATE_CONSTANTS][iplate].size() >= 6)
     {
-      ParseMDFSensorConstants((const Int16*)&data[VAR_FORCE_PLATE_CONSTANTS][iplate][0]);
+      ParseMDFSensorConstants(reinterpret_cast<const Int16*>(&data[VAR_FORCE_PLATE_CONSTANTS][iplate][0]));
     }
 
     // custom outline
@@ -123,7 +123,7 @@ namespace Open3DMotion
         
 				double corner_vector[3] = { 0, 0, 0 };
 				for (size_t j = 0; j < 3; j++)
-					corner_vector[j] = 0.1 * ((const Int16*)&data[VAR_FORCE_PLATE_POSITION][4*iplate+i][0])[j];
+					corner_vector[j] = 0.1 * (reinterpret_cast<const Int16*>(&data[VAR_FORCE_PLATE_POSITION][4*iplate+i][0]))[j];
 
 				Outline[i].SetVector(corner_vector);
       }
@@ -146,7 +146,7 @@ namespace Open3DMotion
 				}
 				for (size_t c = 0; c < 6; c++)
 				{
-          kistler_params[r][c] = ((float*)&data[VAR_FORCE_PLATE_COP_COEFFS][r][0])[c];
+          kistler_params[r][c] = (reinterpret_cast<float*>(&data[VAR_FORCE_PLATE_COP_COEFFS][r][0]))[c];
         }
 			}
 
@@ -187,33 +187,33 @@ namespace Open3DMotion
 
         // get scaled inputs
         float Fy = -1.0f *
-            ((Int16*)&(data[VAR_ANALOGUE_FORCE][platechan0  ][0]))[index_frame]
-            * *(float*)(&data[VAR_FORCE_RESOLUTION][platechan0  ][0]);
+            (reinterpret_cast<Int16*>(&(data[VAR_ANALOGUE_FORCE][platechan0  ][0])))[index_frame]
+            * *reinterpret_cast<float*>(&data[VAR_FORCE_RESOLUTION][platechan0  ][0]);
         float Fx = -1.0f *
-            ((Int16*)&(data[VAR_ANALOGUE_FORCE][platechan0+1][0]))[index_frame]
-            * *(float*)(&data[VAR_FORCE_RESOLUTION][platechan0+1][0]);
+            (reinterpret_cast<Int16*>(&(data[VAR_ANALOGUE_FORCE][platechan0+1][0])))[index_frame]
+            * *reinterpret_cast<float*>(&data[VAR_FORCE_RESOLUTION][platechan0+1][0]);
         float Fz = 
-            ((Int16*)&(data[VAR_ANALOGUE_FORCE][platechan0+2][0]))[index_frame]
-            * *(float*)(&data[VAR_FORCE_RESOLUTION][platechan0+2][0]);
+            (reinterpret_cast<Int16*>(&(data[VAR_ANALOGUE_FORCE][platechan0+2][0])))[index_frame]
+            * *reinterpret_cast<float*>(&data[VAR_FORCE_RESOLUTION][platechan0+2][0]);
         float My = 1000.0f *
-            ((Int16*)&(data[VAR_ANALOGUE_FORCE][platechan0+3][0]))[index_frame]
-            * *(float*)(&data[VAR_FORCE_RESOLUTION][platechan0+3][0]);
+            (reinterpret_cast<Int16*>(&(data[VAR_ANALOGUE_FORCE][platechan0+3][0])))[index_frame]
+            * *reinterpret_cast<float*>(&data[VAR_FORCE_RESOLUTION][platechan0+3][0]);
         float Mx = 1000.0f *
-            ((Int16*)&(data[VAR_ANALOGUE_FORCE][platechan0+4][0]))[index_frame]
-            * *(float*)(&data[VAR_FORCE_RESOLUTION][platechan0+4][0]);
+            (reinterpret_cast<Int16*>(&(data[VAR_ANALOGUE_FORCE][platechan0+4][0])))[index_frame]
+            * *reinterpret_cast<float*>(&data[VAR_FORCE_RESOLUTION][platechan0+4][0]);
         
 				// Mz would be like this but not needed for these calcs
 				// float Mz = 1000.0f *
-        //    ((Int16*)&(data[FileFormatMDF::VAR_ANALOGUE_FORCE][platechan0+5][0]))[index_frame]
-        //    * *(float*)(&data[FileFormatMDF::VAR_FORCE_RESOLUTION][platechan0+5][0]);
+        //    (reinterpret_cast<Int16*>(&data[FileFormatMDF::VAR_ANALOGUE_FORCE][platechan0+5][0]))[index_frame]
+        //    * *reinterpret_cast<float*>(&data[FileFormatMDF::VAR_FORCE_RESOLUTION][platechan0+5][0]);
 
 				// centre of pressure as originally computed
 				float Py = 
-            ((Int16*)&(data[VAR_ANALOGUE_FORCE][platechan0+6][0]))[index_frame]
-            * *(float*)(&data[VAR_FORCE_RESOLUTION][platechan0+6][0]);
+            (reinterpret_cast<Int16*>(&(data[VAR_ANALOGUE_FORCE][platechan0+6][0])))[index_frame]
+            * *reinterpret_cast<float*>(&data[VAR_FORCE_RESOLUTION][platechan0+6][0]);
         float Px = 
-            ((Int16*)&(data[VAR_ANALOGUE_FORCE][platechan0+7][0]))[index_frame]
-            * *(float*)(&data[VAR_FORCE_RESOLUTION][platechan0+7][0]);
+            (reinterpret_cast<Int16*>(&(data[VAR_ANALOGUE_FORCE][platechan0+7][0])))[index_frame]
+            * *reinterpret_cast<float*>(&data[VAR_FORCE_RESOLUTION][platechan0+7][0]);
 
 				if (fabs(Fz) < 1.0)
 					continue;

--- a/src/Open3DMotion/MotionFile/Formats/MDF/MDFDescriptor.cpp
+++ b/src/Open3DMotion/MotionFile/Formats/MDF/MDFDescriptor.cpp
@@ -49,7 +49,7 @@ namespace Open3DMotion
                                      const UInt8* inview,
                                      float scale)
   {
-    const Int16* pos = (const Int16*)data;
+    const Int16* pos = reinterpret_cast<const Int16*>(data);
 		// Int32 num_frames = ts.NumFrames();
     UInt16 wInView(0);
     *(UInt8*)&wInView = *(inview+1);
@@ -101,7 +101,7 @@ namespace Open3DMotion
                                      const UInt8* inview,
                                      float /*scale*/)
   {
-    const float* pos = (const float*)data;
+    const float* pos = reinterpret_cast<const float*>(data);
     UInt16 wInView;
     *(UInt8*)&wInView = *(inview+1);
     *((UInt8*)&wInView+1) = *inview;

--- a/src/Open3DMotion/OpenORM/Mappings/RichBinary/RichBinaryConvertFloat.cpp
+++ b/src/Open3DMotion/OpenORM/Mappings/RichBinary/RichBinaryConvertFloat.cpp
@@ -65,7 +65,7 @@ namespace Open3DMotion
 				{
 					for (size_t idim = 0; idim < ndim; idim++)
 					{
-						*(OutputType*)(ptr_output) = *(const InputType*)(ptr_input);
+						*reinterpret_cast<OutputType*>(ptr_output) = static_cast<OutputType>(*reinterpret_cast<const InputType*>(ptr_input));
 						ptr_input += sizeof(InputType);
 						ptr_output += sizeof(OutputType);
 					}


### PR DESCRIPTION
...rease alignment.

For example: cast from 'value_type *' (aka 'unsigned char *') to 'const Int16 *'
      (aka 'const short *') increases required alignment from 1 to 2
      [-Wcast-align]

The use of the “reinterpret_cast” function fixes that.

I added the flag -Wcast-align, because I wanted to remove the C casting methods from the project Biomechanical-ToolKit and replace them by the adapted C++ code.
